### PR TITLE
Revert "Add rtl support to GlowPadView"

### DIFF
--- a/src/com/android/incallui/widget/multiwaveview/GlowPadView.java
+++ b/src/com/android/incallui/widget/multiwaveview/GlowPadView.java
@@ -56,7 +56,6 @@ import android.view.accessibility.AccessibilityNodeInfo.AccessibilityAction;
 import android.view.accessibility.AccessibilityNodeProvider;
 
 import com.android.incallui.R;
-import com.android.incallui.InCallPresenter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -642,7 +641,7 @@ public class GlowPadView extends View {
         final int count = array.length();
         ArrayList<TargetDrawable> drawables = new ArrayList<TargetDrawable>(count);
         for (int i = 0; i < count; i++) {
-            TypedValue value = array.peekValue(getRtlTarget(i));
+            TypedValue value = array.peekValue(i);
             TargetDrawable target = new TargetDrawable(res, value != null ? value.resourceId : 0, 3);
             drawables.add(target);
         }
@@ -1549,21 +1548,5 @@ public class GlowPadView extends View {
             return false;
         }
 
-    }
-
-    /**
-     * Get the mirrored target iterator if it is in RTL locale
-     */
-    private int getRtlTarget(int id) {
-        if (InCallPresenter.isRtl()) {
-            // In the drawable array, LEFT is array[0], TOP is array[1], RIGHT is array[2]
-            int LEFT = 0, RIGHT = 2;
-            if (id == LEFT) {
-                return RIGHT;
-            } else if (id == RIGHT) {
-                return LEFT;
-            }
-        }
-        return id;
     }
 }


### PR DESCRIPTION
The original patch causes a mismatch between the call action text
and the call action buttons. Although the call action buttons were
swapped for RTL targets, the call action text were not.

As a result, to answer a call, the user has to swipe left to a
button that is green, but whose text is "לא לענות" (Do not answer).
The same goes for the other call action buttons.

This reverts commit 5227cbd5278bf614197b6b0cf85517f82ad0eab8.

Change-Id: I6c677008f4ed246019ae5972b3355d4402d09679